### PR TITLE
Add more repo badges

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,20 +25,20 @@ jobs:
     # https://github.com/marketplace/actions/build-and-push-docker-images#path-context
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # https://github.com/actions/checkout/releases/tag/v4.2.2
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       # Add support for more platforms with QEMU (optional)
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25  # https://github.com/docker/setup-qemu-action/releases/tag/v3.4.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca  # https://github.com/docker/setup-buildx-action/releases/tag/v3.9.0
       
       # https://github.com/marketplace/actions/docker-login
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # https://github.com/docker/login-action/releases/tag/v3.3.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -67,7 +67,7 @@ jobs:
 
       # https://github.com/marketplace/actions/build-and-push-docker-images
       - name: Build and Push Multi-Arch Docker Image By docker action
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991  # https://github.com/docker/build-push-action/releases/tag/v6.13.0
         env:
           DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,15 @@ jobs:
           name: code-coverage-report
           path: coverage/
 
+      # https://github.com/marketplace/actions/codecov
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      # https://github.com/marketplace/actions/codacy-coverage-reporter
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       # https://github.com/marketplace/actions/checkout
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # https://github.com/actions/checkout/releases/tag/v4.2.2
 
       # https://github.com/marketplace/actions/setup-node-js-environment
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # https://github.com/actions/setup-node/releases/tag/v4.2.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -39,7 +39,7 @@ jobs:
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#example
       # https://github.com/marketplace/actions/upload-a-build-artifact
       - name: Archive Code Coverage Report (Only for Node.js 22)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # https://github.com/actions/upload-artifact/releases/tag/v4.6.0
         if: ${{ matrix.node-version == 22 }}
         with:
           name: code-coverage-report
@@ -54,25 +54,25 @@ jobs:
     needs: ci
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # https://github.com/actions/checkout/releases/tag/v4.2.2
 
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#downloading-artifacts-during-a-workflow-run
       # https://github.com/marketplace/actions/download-a-build-artifact
       - name: Download Code Coverage Report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # https://github.com/actions/download-artifact/releases/tag/v4.1.8
         with:
           name: code-coverage-report
           path: coverage/
 
       # https://github.com/marketplace/actions/codecov
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # https://github.com/codecov/codecov-action/releases/tag/v5.3.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       # https://github.com/marketplace/actions/codacy-coverage-reporter
       - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # https://github.com/codacy/codacy-coverage-reporter-action/releases/tag/v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/W-Shih/OOADP-showdown-game/actions/workflows/ci.yml/badge.svg)](https://github.com/W-Shih/OOADP-showdown-game/actions/workflows/ci.yml?query=branch%3Amain)
 [![CD](https://github.com/W-Shih/OOADP-showdown-game/actions/workflows/cd.yml/badge.svg)](https://github.com/W-Shih/OOADP-showdown-game/actions/workflows/cd.yml?query=branch%3Amain)
+[![Codacy code quality](https://app.codacy.com/project/badge/Grade/8e644233caca4cd9be81a73d2ce77d2b)](https://app.codacy.com/gh/W-Shih/OOADP-showdown-game/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy test coverage](https://app.codacy.com/project/badge/Coverage/8e644233caca4cd9be81a73d2ce77d2b)](https://app.codacy.com/gh/W-Shih/OOADP-showdown-game/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 [![Codecov test coverage](https://codecov.io/gh/W-Shih/OOADP-showdown-game/branch/main/graph/badge.svg)](https://app.codecov.io/gh/W-Shih/OOADP-showdown-game/tree/main)
 [![Docker Image Version (tag)](https://img.shields.io/docker/v/wshih/ooadp-showdown-game/latest?label=dockerhub)](https://hub.docker.com/repository/docker/wshih/ooadp-showdown-game/general)
 [![multi-arch images (Static Badge)](https://img.shields.io/badge/multi--arch%20images-amd64%2C%20arm64-blue)](https://hub.docker.com/repository/docker/wshih/ooadp-showdown-game/general)


### PR DESCRIPTION
- ci: upload coverage reports to `codacy`
- ci: pin workflows' actions to specific commit hashes for stability
- doc: add `codacy` badges