### PR TITLE
Use OIDC for codecov

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,4 @@
+# https://docs.codacy.com/repositories-configure/codacy-configuration-file/#using-a-codacy-configuration-file
 ---
 engines:
   duplication:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # https://github.com/docker/login-action/releases/tag/v3.3.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}  # https://github.com/docker/roadmap/issues/314#issuecomment-2605945137
 
       - name: Set IMAGE_NAME and IMAGE_VERSION
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - opened
       - reopened
 
+permissions:
+  id-token: write  # 啟用 OIDC token
+  contents: read
+
 jobs:
   ci:
     name: Continuous Integration (CI)
@@ -68,7 +72,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # https://github.com/codecov/codecov-action/releases/tag/v5.3.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true  # https://github.com/marketplace/actions/codecov#using-oidc
 
       # https://github.com/marketplace/actions/codacy-coverage-reporter
       - name: Run codacy-coverage-reporter


### PR DESCRIPTION
- ci: switch to OIDC for `Codecov` access instead of long-lived `CODECOV_TOKEN` for improved security